### PR TITLE
Add basic CI check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: rust
 rust:
-  - 1.35
+  - stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: rust
+rust:
+  - 1.35


### PR DESCRIPTION
Should compile and run `cargo test` (that's the default in travis for rust). It's using the *stable* channel.